### PR TITLE
bug: update count number in cart items, when click multiple times update just onces

### DIFF
--- a/src/componets/Navbar.js
+++ b/src/componets/Navbar.js
@@ -13,7 +13,7 @@ class Navbar extends Component {
   componentDidUpdate(prevProps) {
     const { cartReducer } = this.props;
     if (cartReducer.cart !== prevProps.cartReducer.cart) {
-      this.setState({ cartCount: cartReducer.cart.length });
+      this.setState({ cartCount: cartReducer.cart.map(item => item.quantity).reduce((a, b) => a + b, 0) });
     }
   }
 


### PR DESCRIPTION
_Grettings,_

**Problem:** update count number in cart items 
![image](https://github.com/user-attachments/assets/237b0f15-3b20-42b4-ae96-e992e4b330dc)

- Fixed the bug when in the navbar, the count number only updated when clicked once in the "add to cart" button, but kept incrementing behind the scenes on the checkout page

![image](https://github.com/user-attachments/assets/4d1786f1-4498-4262-b65b-ca45ba84b28e)

**Solution:** Use the built-in reduce method in the "cartReducer.cart" array and add all the item quantities of each product.
